### PR TITLE
Pull: fix crash if no versionCode is set

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ options:
 > [!IMPORTANT]
 > This file should be placed in the modules root directory
 
-```json
+```jsonc
 {
   "support": "str",
   "donate": "str",
@@ -176,7 +176,12 @@ options:
   "screenshots": ["array"],
   "category": "str",
   "categories": ["array"],
-  "require": ["array"]
+  "require": ["array"],
+  "note": {
+    "title": "str" // optional
+    "color": "red,blue,yellow,green", // optional
+    "message": "str" // required
+  }
 }
 ```
 
@@ -193,6 +198,7 @@ options:
 | homepage     | optional  | Url         |
 | support      | optional  | Url         |
 | donate       | optional  | Url         |
+| note         | optional  | Note        |
 
 ### Update from updateJson
 

--- a/sync/core/Pull.py
+++ b/sync/core/Pull.py
@@ -55,6 +55,9 @@ class Pull:
             return True
 
         update_json = UpdateJson.load(json_file)
+        if version_code is None:
+          self._log.e(f"_check_version_code: [{module_id}] has no version code set")
+          return False
         if len(update_json.versions) != 0 and version_code > update_json.versions[-1].versionCode:
             return True
 


### PR DESCRIPTION
If a module has no versionCode set (like currently `magisk-autoboot`) this leads to a crash on sync:

```
Traceback (most recent call last):
  File "util/cli.py", line 26, in <module>
    sys.exit(Main.exec())
  File "util/sync/cli/Main.py", line 62, in exec
    code = cls._check_args()
  File "util/sync/cli/Main.py", line 82, in _check_args
    return cls.sync()
  File "util/sync/cli/Main.py", line 261, in sync
    sync.update(
  File "util/sync/core/Sync.py", line 153, in update
    online_module = future.result()
  File "/usr/lib/python3.10/concurrent/futures/_base.py", line 451, in result
    return self.__get_result()
  File "/usr/lib/python3.10/concurrent/futures/_base.py", line 403, in __get_result
    raise self._exception
  File "/usr/lib/python3.10/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
  File "util/sync/core/Sync.py", line 40, in _update_jsons
    online_module, timestamp = self._pull.from_track(track)
  File "util/sync/core/Pull.py", line 247, in from_track
    return self.from_json(track, local=False)
  File "util/sync/core/Pull.py", line 190, in from_json
    online_module = self._from_zip_common(track, zip_file, changelog, delete_tmp=True)
  File "util/sync/core/Pull.py", line 137, in _from_zip_common
    if self._check_version_code(track.id, online_module.versionCode):
  File "util/sync/core/Pull.py", line 58, in _check_version_code
    if len(update_json.versions) != 0 and version_code > update_json.versions[-1].versionCode:
TypeError: '>' not supported between instances of 'NoneType' and 'int'
```

(some path info has been sanitized in the stack trace). This PR fixes this and instead returns a proper error message, then skips the broken module:

```
[2024/08/08 17:01:45] Pull ERROR: _check_version_code: [magisk-autoboot] has no version code set
```
